### PR TITLE
make the code in readme.md work without additional line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,17 +6,29 @@ An [egui](https://github.com/emilk/egui/) implementation for the [ggez](https://
 ## Ultra minimal example
 ```rust
 use ggegui::{egui, Gui};
+use ggez::{
+	ContextBuilder, Context, GameResult, glam,
+	event::{ self, EventHandler}, 
+	graphics::{ self, DrawParam, Color }
+};
+
+fn main() {
+	let (mut ctx, event_loop) = ContextBuilder::new("game_id", "author").build().unwrap();
+	let state = State::new(&mut ctx);
+	event::run(ctx, event_loop, state);
+}
+
 struct State {
 	gui: Gui,
-}
+} 
 
 impl State {
 	pub fn new(ctx: &mut Context) -> Self {
-		Self {
+		Self { 
 			gui: Gui::new(ctx),
 		}
-	}
-}
+	} 
+} 
 
 impl EventHandler for State {
 	fn update(&mut self, ctx: &mut Context) -> GameResult {
@@ -35,7 +47,7 @@ impl EventHandler for State {
 	fn draw(&mut self, ctx: &mut Context) -> GameResult {
 		let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
 		canvas.draw(
-			&self.egui_backend,
+			&self.gui, 
 			DrawParam::default().dest(glam::Vec2::ZERO),
 		);
 		canvas.finish(ctx)


### PR DESCRIPTION
I found that the code inside readme.md doesn't work if it just copypaste'd and run it.
I think it will be great if people can immediately test the code from readme.md without the need to add something else.

I also found typo in the draw method