### PR TITLE
Fixing painter to work with multiple `textures_delta`s

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -24,7 +24,7 @@ impl Painter {
 
 	pub fn update(&mut self, ctx: &mut ggez::Context) {
 		// Create and free textures
-		if let Some(textures_delta) = self.textures_delta.pop_front() {
+		while let Some(textures_delta) = self.textures_delta.pop_front() {
 			self.update_textures(ctx, textures_delta);
 		}
 


### PR DESCRIPTION
Painter::draw was failing for me because not all textures were updated. This seems to fix the problem.