### PR TITLE
Fixed issue with resizing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ impl Gui {
 	pub fn update(&mut self, ctx: &mut ggez::Context) {
 		self.input.update(ctx);
 		self.painter.lock().unwrap().update(ctx);
+		self.input.set_scale_factor(1.0, ctx.gfx.size());
 	}
 
 	/// Return an [`EguiContext`] for update the gui


### PR DESCRIPTION
Windows used to not be able to move past the old bounds of their window.

With one simple line of code, this bug is fixed!