### PR TITLE
update egui and ggez versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ description = "A simple implementation of egui for ggez"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.20.1"
-ggez = "0.8.1"
+egui = "0.21.0"
+ggez = "0.9.0-rc0"

--- a/src/input.rs
+++ b/src/input.rs
@@ -45,6 +45,7 @@ impl Input {
 				self.raw.events.push(egui::Event::Key {
 					key,
 					pressed: true,
+					repeat: false,
 					modifiers: translate_modifier(ctx.keyboard.active_mods()),
 				})
 			}


### PR DESCRIPTION
Updated to 0.9.0-rc0 ggez version because 0.8.1 does not work for me. Also updated egui to latest. See the [relevant docs for egui 0.21.0 ](https://docs.rs/egui/0.21.0/egui/enum.Event.html#variant.Key.field.repeat) regarding the repeat field.