### PR TITLE
Fix scale_factor not used in window update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,39 +46,39 @@ impl Drop for GuiContext {
 /// ```
 /// use ggegui::{egui, Gui};
 /// struct State {
-/// 	gui: Gui,
+///     gui: Gui,
 /// }
 ///
 /// impl State {
-/// 	pub fn new(ctx: &mut Context) -> Self {
-/// 		Self {
-/// 			gui: Gui::new(ctx),
-/// 		}
-/// 	}
+///     pub fn new(ctx: &mut Context) -> Self {
+///         Self {
+///             gui: Gui::new(ctx),
+///         }
+///     }
 /// }
 ///
 /// impl EventHandler for State {
-/// 	fn update(&mut self, ctx: &mut Context) -> GameResult {
-/// 		let gui_ctx = self.gui.ctx();
+///     fn update(&mut self, ctx: &mut Context) -> GameResult {
+///         let gui_ctx = self.gui.ctx();
 ///
-/// 		egui::Window::new("Title").show(&gui_ctx, |ui| {
-/// 			ui.label("label");
-/// 			if ui.button("button").clicked() {
-/// 				println!("button clicked");
-/// 			}
-/// 		});
-///			self.gui.update(ctx);
-/// 		Ok(())
-/// 	}
+///         egui::Window::new("Title").show(&gui_ctx, |ui| {
+///             ui.label("label");
+///             if ui.button("button").clicked() {
+///                 println!("button clicked");
+///             }
+///         });
+///            self.gui.update(ctx);
+///         Ok(())
+///     }
 ///
-/// 	fn draw(&mut self, ctx: &mut Context) -> GameResult {
-/// 		let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
-/// 		canvas.draw(
-/// 			&self.egui_backend,
-/// 			DrawParam::default().dest(glam::Vec2::ZERO),
-/// 		);
-/// 		canvas.finish(ctx)
-/// 	}
+///     fn draw(&mut self, ctx: &mut Context) -> GameResult {
+///         let mut canvas = graphics::Canvas::from_frame(ctx, Color::BLACK);
+///         canvas.draw(
+///             &self.egui_backend,
+///             DrawParam::default().dest(glam::Vec2::ZERO),
+///         );
+///         canvas.finish(ctx)
+///     }
 /// }
 /// ```
 #[derive(Default)]
@@ -102,8 +102,11 @@ impl Gui {
 
 	pub fn update(&mut self, ctx: &mut ggez::Context) {
 		self.input.update(ctx);
-		self.painter.lock().unwrap().update(ctx);
-		self.input.set_scale_factor(1.0, ctx.gfx.size());
+		self.painter
+			.lock()
+			.unwrap()
+			.update(ctx, self.input.scale_factor);
+		// self.input.set_scale_factor(1.0, ctx.gfx.size());
 	}
 
 	/// Return an [`EguiContext`] for update the gui

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -16,7 +16,7 @@ impl Painter {
 			canvas.set_scissor_rect(*clip).unwrap();
 			canvas.draw_textured_mesh(
 				mesh.clone(),
-				self.textures[&id].clone(),
+				self.textures[id].clone(),
 				graphics::DrawParam::default().scale([scale_factor, scale_factor]),
 			);
 		}
@@ -24,7 +24,7 @@ impl Painter {
 		self.paint_jobs.clear();
 	}
 
-	pub fn update(&mut self, ctx: &mut ggez::Context) {
+	pub fn update(&mut self, ctx: &mut ggez::Context, scale_factor: f32) {
 		// Create and free textures
 		while let Some(textures_delta) = self.textures_delta.pop_front() {
 			self.update_textures(ctx, textures_delta);
@@ -62,10 +62,10 @@ impl Painter {
 							},
 						),
 						graphics::Rect::new(
-							clip_rect.min.x,
-							clip_rect.min.y,
-							clip_rect.max.x - clip_rect.min.x,
-							clip_rect.max.y - clip_rect.min.y,
+							clip_rect.min.x * scale_factor,
+							clip_rect.min.y * scale_factor,
+							(clip_rect.max.x - clip_rect.min.x) * scale_factor,
+							(clip_rect.max.y - clip_rect.min.y) * scale_factor,
 						),
 					));
 				}


### PR DESCRIPTION
In the current version of ggegui the scale factor is reset to `1.0` at the end of the update function (called every frame) so setting a custom scale factor is useless.

This pull request fixes that.

Im  not used to pull requests so if i did something wrong please inform me.

Have a good day