### PR TITLE
Update egui to 0.22.0 & ggez to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ggegui"
 version = "0.3.5"
 edition = "2021"
 authors = ["NemuiSen <NemuiSen@proton.me>"]
-license  = "MIT"
+license = "MIT"
 repository = "https://github.com/NemuiSen/ggez-egui"
 keywords = ["ggez", "egui", "gui", "gamedev"]
 description = "A simple implementation of egui for ggez"
@@ -11,5 +11,5 @@ description = "A simple implementation of egui for ggez"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.21.0"
-ggez = "0.9.0-rc0"
+egui = "0.22.0"
+ggez = "0.9.0"


### PR DESCRIPTION
Updated to the latest dependency versions.
@NemuiSen should I change the version of the ggegui crate to 0.3.6?