### PR TITLE
Don't invalidate existing textures with partial texture data

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -83,6 +83,10 @@ impl Painter {
 	) {
 		// set textures
 		for (id, delta) in &textures_delta.set {
+			if delta.pos.is_some() {
+				eprintln!("Error: Non-zero offset texture updates are not implemented yet");
+				continue;
+			}
 			let image = match &delta.image {
 				egui::ImageData::Color(image) => color_to_image(image, ctx),
 				egui::ImageData::Font(image) => font_to_image(image, ctx),


### PR DESCRIPTION
The current code just assumes all texture deltas are whole images, which is not true, and writing partial texture data can overwrite the existing textures with garbage data.

This change makes the texture update loop ignore non-zero offset deltas which are assumed to be partial data, since they are at a non-zero offset.

Proper partial updates can be implemented in the future.