### PR TITLE
Correctly set whether keys are pressed using info from ggez

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -41,14 +41,15 @@ impl Input {
 	pub fn update(&mut self, ctx: &ggez::Context) {
 		/*======================= Keyboard =======================*/
 		for key in ctx.keyboard.pressed_keys() {
-			let pressed = ctx.keyboard.is_key_just_pressed(*key);
-			if let Some(key) = translate_keycode(*key) {
-				self.raw.events.push(egui::Event::Key {
-					key,
-					pressed,
-					repeat: false,
-					modifiers: translate_modifier(ctx.keyboard.active_mods()),
-				})
+			if ctx.keyboard.is_key_just_pressed(*key) {
+				if let Some(key) = translate_keycode(*key) {
+					self.raw.events.push(egui::Event::Key {
+						key,
+						pressed: true,
+						repeat: false,
+						modifiers: translate_modifier(ctx.keyboard.active_mods()),
+					})
+				}
 			}
 		}
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,10 +41,11 @@ impl Input {
 	pub fn update(&mut self, ctx: &ggez::Context) {
 		/*======================= Keyboard =======================*/
 		for key in ctx.keyboard.pressed_keys() {
+			let pressed = ctx.keyboard.is_key_just_pressed(*key);
 			if let Some(key) = translate_keycode(*key) {
 				self.raw.events.push(egui::Event::Key {
 					key,
-					pressed: true,
+					pressed,
 					repeat: false,
 					modifiers: translate_modifier(ctx.keyboard.active_mods()),
 				})


### PR DESCRIPTION
In the current version, every key that is pressed on the keyboard will be sent as a new "pressed" event every frame, leading to continuous repeat inputs in egui.

This changes it to use the `is_key_just_pressed()` function to check if the key has just been pressed, and pass this into egui, fixing the problem.